### PR TITLE
Added Colors for listinputs

### DIFF
--- a/thesis_main.tex
+++ b/thesis_main.tex
@@ -37,6 +37,9 @@
 
 \definecolor{dunkelgrau}{rgb}{0.8,0.8,0.8}
 \definecolor{hellgrau}{rgb}{0.0,0.7,0.99}
+% Colors for listings
+\definecolor{mauve}{rgb}{0.58,0,0.82}
+\definecolor{dkgreen}{rgb}{0,0.6,0}
 
 % sauber formatierter Quelltext
 \usepackage{listings}


### PR DESCRIPTION
Damit es auch funktioniert sauberen Quellcode einzubinden, müssen diese Farben noch definiert werden...
Die wurden bisher zwar in \lstset als commentstyle und stringstyle  aufgerufen, aber nirgends definiert...
Nun funktioniert es.