### PR TITLE
Online Einträge definiert

### DIFF
--- a/skripte/modsBiblatex.tex
+++ b/skripte/modsBiblatex.tex
@@ -71,10 +71,12 @@ bibwarn=true, % Warnung bei fehlerhafter bib-Datei
   \printnames{author}%
   \newunit\newblockpunct
   \printfield{title}%
-  \setunit*{.\space}%
+  \setunit*{,\space}%
   %\newunit\newblock
   \printfield{url}%
-  \setunit*{.\space}%
+  \setunit*{,\space Erscheinungsjahr:\space}%
+  \printfield{year}%
+  \setunit*{,\space Aufruf am:\space}%
   \printfield{note}%
   \finentry}
   


### PR DESCRIPTION
Online-Einträge wurden nun richtig definiert, so wie sie die FOM gerne hätte.
Als Jahr sollte das Erscheinungsdatum angegeben werden, als Note den Zeitpunkt des Aufrufes, Titel und URL sollten selbsterklärend sein.