### PR TITLE
Run Bash File from this directory

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-
-CURRENT_DIR=`pwd`
+#Run the Script from the folder you are in...
+CURRENT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 pdflatex "$CURRENT_DIR/thesis_main.tex"
 RETVAL="$?"


### PR DESCRIPTION
Wenn man das Bash Skript ausführt, während man in einem anderen Folder noch ist bzw vorher auf dem Terminal woanders hin navigiert hat, funktioniert nur pwd nicht. 
Diese Lösung hier funktioniert immer. 
