### PR TITLE
fixes travis-ci config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
+dist: trusty
 before_install:
-  - sudo add-apt-repository ppa:texlive-backports/ppa -y
+  - sudo add-apt-repository ppa:jonathonf/texlive -y
   - sudo apt-get update
 
 install:
-  - sudo apt-get install texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended biblatex texlive-lang-german
-  - wget http://sourceforge.net/projects/biblatex-biber/files/biblatex-biber/0.9.9/binaries/Linux/biber-linux_x86_64.tar.gz/download --output-document biber-linux_x86_32.tar.gz
-  - tar -xvzf biber-linux_x86_32.tar.gz
+  - sudo apt-get install -y texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended texlive-bibtex-extra texlive-lang-german texlive-generic-extra
+  - wget https://sourceforge.net/projects/biblatex-biber/files/biblatex-biber/2.4/binaries/Linux/biber-linux_x86_64.tar.gz/download --output-document biber-linux_x86_64.tar.gz
+  - tar -xvzf biber-linux_x86_64.tar.gz
   - sudo mv biber /usr/bin/
 
 script:


### PR DESCRIPTION
Hallo Andy,

ich habe mich an die Travis CI config gesetzt. Das kompilieren des Dokuments ist mit der neuen Konfiguration wieder möglich:
https://travis-ci.org/chilian/FOM-LaTeX-Template/builds/141555232

Mir gefällt noch nicht das 859 MB für jeden Test runter geladen werden müssen. Ggf. optimiere ich das noch um die Laufzeit beim Build zu minimieren.

VG
Christoph