### PR TITLE
Remove custom installation of biber

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ before_install:
 
 install:
   - sudo apt-get install -y texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended texlive-bibtex-extra texlive-lang-german texlive-generic-extra
-  - wget https://sourceforge.net/projects/biblatex-biber/files/biblatex-biber/2.4/binaries/Linux/biber-linux_x86_64.tar.gz/download --output-document biber-linux_x86_64.tar.gz
-  - tar -xvzf biber-linux_x86_64.tar.gz
-  - sudo mv biber /usr/bin/
 
 script:
   - pdflatex --version


### PR DESCRIPTION
Das würde die Warning mit unterschiedlichen Biber / biblatex-Versionen fixen:

```
INFO - This is Biber 2.4
INFO - Logfile is 'thesis_main.blg'
INFO - Reading 'thesis_main.bcf'
WARN - Warning: Found biblatex control file version 3.1, expected version 3.0
INFO - Found 2 citekeys in bib section 0
INFO - Processing section 0
INFO - Looking for bibtex format file 'literatur/literatur.bib' for section 0
INFO - Decoding LaTeX character macros into UTF-8
INFO - Found BibTeX data source 'literatur/literatur.bib'
INFO - Overriding locale 'de' defaults 'normalization = NFD' with 'normalization = prenormalized'
INFO - Overriding locale 'de' defaults 'variable = shifted' with 'variable = non-ignorable'
INFO - Sorting list 'nty/global/' of type 'entry' with scheme 'nty' and locale 'de'
INFO - No sort tailoring available for locale 'de'
INFO - Overriding locale 'de' defaults 'normalization = NFD' with 'normalization = prenormalized'
INFO - Overriding locale 'de' defaults 'variable = shifted' with 'variable = non-ignorable'
INFO - Sorting list 'nty/global' of type 'entry' with scheme 'nty' and locale 'de'
INFO - No sort tailoring available for locale 'de'
INFO - Writing 'thesis_main.bbl' with encoding 'UTF-8'
INFO - Output to thesis_main.bbl
INFO - WARNINGS: 1
```