### PR TITLE
Kompilieren mit Docker

### DIFF
--- a/compile_with_docker.bat
+++ b/compile_with_docker.bat
@@ -1,0 +1,3 @@
+cd /d %~dp0
+docker run -it --rm -v "pwd":/data andygrunwald/fom-latex-template
+pause


### PR DESCRIPTION
Diese Datei setzt den aktuellen Pfad des Ordners und ruft das Compilieren mit Hilfe des Docker-Containers auf. 
Durch den Befehl pause wird die Kommandozeile nicht direkt geschlossen.
@andygrunwald was hältst du davon? Dann muss man nicht immer zur Github Seite um den Docker-Befehl wieder zu kopieren. Außerdem wird die Anleitung dann wesentlich einfacher: Um mit Docker zu kompilieren, rufe die compile_with_docker.bat Datei unter Windows auf. 
Dann müssen wir nur noch ein ähnliches Shell Skript für Mac schreiben... 