### PR TITLE
Add current year to LICENCE and fix typo

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Andreas Grunwald & contributer
+Copyright (c) 2018 Andreas Grunwald & contributers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Es wird das aktuelle Jahr verwendet und ein Rechtschreibfehler in der LICENCE-Datei korrigiert.