### PR TITLE
Inproceedings verbessern

### DIFF
--- a/skripte/modsBiblatex2018.tex
+++ b/skripte/modsBiblatex2018.tex
@@ -35,6 +35,13 @@
   \clearfield{url}
   \clearfield{eprint}
 }{}
+\ifentrytype{inproceedings}{
+  \clearfield{issn}%
+  \clearfield{doi}%
+  \clearfield{isbn}%
+  \clearfield{url}
+  \clearfield{eprint}
+}{}
 }
 
 \renewcommand*{\finentrypunct}{}%Kein Punkt am ende des Literaturverzeichnisses


### PR DESCRIPTION
Die Felder DOI, issn, isbn, url und eprint werden nach FOM Leitfaden 2018 bei inproceedings nicht genutzt.
Für die Anzeige werden sie deshalb geleert.