### PR TITLE
Sammelwerk & Literaturdarstellung

### DIFF
--- a/thesis_main.tex
+++ b/thesis_main.tex
@@ -83,7 +83,8 @@ urldate=iso,
 innamebeforetitle,
 dashed=false,
 autocite=footnote,
-doi=false
+doi=false,
+mincrossrefs = 1
 ]{biblatex}%iso dateformat für YYYY-MM-DD
 
 %weitere Anpassungen für BibLaTex
@@ -307,6 +308,13 @@ doi=false
 %\printbibliography[type=article,heading=subbibliography,title={Artikel}]
 %\printbibliography[type=book,heading=subbibliography,title={Bücher}]
 %\printbibliography[type=online,heading=subbibliography,title={Webseiten}]
+
+% weitere Variante, die nur Online von anderen Quellen trennt:
+
+%\printbibheading
+%\printbibliography[nottype=online,heading=subbibliography,title={Literaturquellen}]
+%\printbibliography[type=online,heading=subbibliography,title={Internetquellen}]
+
 
 % Um mehrere Typen zu vereinen kann ein Bibliography-Filter verwendet werden
 % \defbibfilter{literature}{


### PR DESCRIPTION
Sammelwerke werden so auch mit nur einer Referenz angezeigt gem. Leitfaden und eine "einfachere" Aufteilung des Literaturverzeichnisses.