### PR TITLE
Add JavaScript Highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,8 @@ Folgendermaßen könnt ihr Quellcode einbauen:
 \lstinputlisting[language=Java]{./Quellcode/Dateiname.js}
 ```
 
-Für [Javascript](https://de.wikipedia.org/wiki/JavaScript) gibt es noch keine eigene Sprache, daher benutzt am besten [Java](https://de.wikipedia.org/wiki/Java_(Programmiersprache)).
-Für eine genauere Beschreibung empfehlen wir folgenden Artikel: [LaTeX/Source Code Listings @ Wikibooks](http://en.wikibooks.org/wiki/LaTeX/Source_Code_Listings).
+Für [Javascript](https://de.wikipedia.org/wiki/JavaScript) wurde eine eigene Definition erstellt und eingebaut. 
+Für eine genauere Beschreibung aller im Standard verfügbaren Sprachen empfehlen wir folgenden Artikel: [LaTeX/Source Code Listings @ Wikibooks](http://en.wikibooks.org/wiki/LaTeX/Source_Code_Listings).
 
 ## Einheitliche Schriftarten erzwingen
 

--- a/thesis_main.tex
+++ b/thesis_main.tex
@@ -54,7 +54,25 @@
 
 % sauber formatierter Quelltext
 \usepackage{listings}
-\lstset{numbers=left,
+% JavaScript als Sprache definieren:
+\lstdefinelanguage{JavaScript}{
+	keywords={break, super, case, extends, switch, catch, finally, for, const, function, try, continue, if, typeof, debugger, var, default, in, void, delete, instanceof, while, do, new, with, else, return, yield, enum, let, await},
+	keywordstyle=\color{blue}\bfseries,
+	ndkeywords={class, export, boolean, throw, implements, import, this, interface, package, private, protected, public, static},
+	ndkeywordstyle=\color{darkgray}\bfseries,
+	identifierstyle=\color{black},
+	sensitive=false,
+	comment=[l]{//},
+	morecomment=[s]{/*}{*/},
+	commentstyle=\color{purple}\ttfamily,
+	stringstyle=\color{red}\ttfamily,
+	morestring=[b]',
+	morestring=[b]"
+}
+
+\lstset{
+	language=JavaScript,
+	numbers=left,
 	numberstyle=\tiny,
 	numbersep=5pt,
 	breaklines=true,

--- a/thesis_main.tex
+++ b/thesis_main.tex
@@ -71,7 +71,7 @@
 }
 
 \lstset{
-	language=JavaScript,
+	%language=JavaScript,
 	numbers=left,
 	numberstyle=\tiny,
 	numbersep=5pt,


### PR DESCRIPTION
JavaScript wird als Syntax-Highlighting von Listings nicht unterstützt.
Man kann es jedoch, wie hier geschehen, selbst implementieren.