### PR TITLE
Change travis exit code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ before_script:
   - docker build -t andygrunwald/fom-latex-template .
 
 script:
-  - docker-compose up
+  - docker-compose up --exit-code-from fom


### PR DESCRIPTION
At the moment, travis do not fail because of the exit code of docker-compose. This change takes the exit code of the fom container.