### PR TITLE
Umlaute mit LuaLatex

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN echo 'deb [trusted=yes] http://ppa.launchpad.net/jonathonf/texlive-2018/ubun
 		texlive-bibtex-extra \
 		texlive-lang-german \
 		texlive-generic-extra \
+		texlive-luatex \
 		biber \
 		xz-utils \
 		python \

--- a/thesis_main.tex
+++ b/thesis_main.tex
@@ -25,6 +25,7 @@
    \ifen\selectlanguage{english}#1\fi}
 \langde{\usepackage[babel,german=quotes]{csquotes}}
 \langen{\usepackage[babel,english=british]{csquotes}}
+\usepackage[utf8]{luainputenc}
 \usepackage[T1]{fontenc}
 \usepackage{fancyhdr}
 \usepackage{fancybox}


### PR DESCRIPTION
Hallo zusammen,
kompiliere ich eine Datei mit den letzten Änderungen (Also auch LuaLatex) in Visual Studio Code, so werden Umlaute nicht mehr korrekt dargestellt. Aus "ß" wird z.B. "SS".

Das scheint am Befehl \usepackage[T1]{fontenc} zu liegen. Das Paket fontenc ist inkompatibel mit LuaLatex. Wird der Befehl entfernt führt das stattdessen zu einer falschen Schriftart.
Bei mir hilft es das Paket luaiputenc einzubinden. Wird z.B. hier auch empfohlen:
https://texfragen.de/was_muss_ich_beim_umstieg_auf_luatex_beachten

Mir erschließt sich allerdings nicht ganz, wie die aktuelle PDF so überhaupt entstehen konnte. @ChristianLuxem kannst du ohne den Merge hier mit LuaLatex ein PDF kompilieren?

Ansonten prüft bitte gerne alle einmal, ob es so für euch funktioniert.

Danke.

EDIT: Gerade gesehen: Offenbar hatte es auch in der aktuell als Master eingecheckten Version nicht richtig funktioniert. Auf Seite 6 steht "standardmäSSig", anstelle von "standardmäßig".