### PR TITLE
Leerzeichen bei fehlendem urltime

### DIFF
--- a/skripte/modsBiblatex2018.tex
+++ b/skripte/modsBiblatex2018.tex
@@ -84,7 +84,7 @@
   {}{} 
 
 \DeclareFieldFormat[online]{date}{\mkbibparens{#1}} 
-\DeclareFieldFormat{urltime}{#1\addspace \langde{Uhr}\langen{MEZ}}
+\DeclareFieldFormat{urltime}{\addspace #1\addspace \langde{Uhr}\langen{MEZ}}
 \DeclareFieldFormat{urldate}{%urltime zu urldate hinzufügen
   [\langde{Zugriff}\langen{Access}\addcolon\addspace
   #1\printfield{urltime}]

--- a/skripte/modsBiblatex2018.tex
+++ b/skripte/modsBiblatex2018.tex
@@ -87,8 +87,7 @@
 \DeclareFieldFormat{urltime}{#1\addspace \langde{Uhr}\langen{MEZ}}
 \DeclareFieldFormat{urldate}{%urltime zu urldate hinzufügen
   [\langde{Zugriff}\langen{Access}\addcolon\addspace
-  #1
-  \printfield{urltime}]
+  #1\printfield{urltime}]
 }
 \DeclareFieldFormat[online]{url}{\mkbibacro{URL}\addcolon\space <\url{#1}>}
 \renewbibmacro*{url+urldate}{% 


### PR DESCRIPTION
Hiermit wird das Leerzeichen vor urltime nur noch dann eingefügt, wenn dieses Feld gefüllt ist. 