### PR TITLE
Sperrvermerk an falscher Stelle

### DIFF
--- a/thesis_main.tex
+++ b/thesis_main.tex
@@ -274,11 +274,6 @@ mincrossrefs = 1
 \input{kapitel/titelseite}
 
 %-----------------------------------
-% Sperrvermerk
-%-----------------------------------
-%\input{kapitel/anhang/sperrvermerk}
-
-%-----------------------------------
 % Inhaltsverzeichnis
 %-----------------------------------
 \setcounter{page}{2}
@@ -303,6 +298,12 @@ mincrossrefs = 1
 %-----------------------------------
 \input{abkuerzungen/acronyms}
 \newpage
+
+%-----------------------------------
+% Sperrvermerk
+%-----------------------------------
+%\input{kapitel/anhang/sperrvermerk}
+
 %-----------------------------------
 % Seitennummerierung auf arabisch und ab 1 beginnend umstellen
 %-----------------------------------


### PR DESCRIPTION
Moin,
laut Leitfaden ist der Sperrvermerk "dem Textteil voranzustellen [...] und nach den Verzeichnissen vor dem Text folgt".

Entsprechend muss er verschoben werden.

Da der Sperrvermerk im PDF nicht angezeigt wird spare ich mir das neu kompilieren.