### PR TITLE
Datum und Unterschrift in Sperrvermerk

### DIFF
--- a/kapitel/anhang/sperrvermerk.tex
+++ b/kapitel/anhang/sperrvermerk.tex
@@ -7,11 +7,21 @@
 \section*{Sperrvermerk}
 Die vorliegende Abschlussarbeit mit dem Titel \enquote{\myTitel} enthält unternehmensinterne Daten der Firma \myFirma . Daher ist sie nur zur Vorlage bei der FOM sowie den Begutachtern der Arbeit bestimmt. Für die Öffentlichkeit und dritte Personen darf sie nicht zugänglich sein.
 
-\par\medskip
-\par\medskip
+\vspace{5cm}
 
-\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_ \hspace{1.5cm} \_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_ \\
-(Ort, Datum)\hspace{4.5cm}
-(Eigenhändige Unterschrift)
+\begin{table}[H]
+	\centering
+	\begin{tabular*}{\textwidth}{c @{\extracolsep{\fill}} ccccc}
+		\myOrt, \today
+		&
+		% Hinterlege deine eingescannte Unterschrift im Verzeichnis /abbildungen und nenne sie unterschrift.png
+		% Bilder mit transparentem Hintergrund können teils zu Problemen führen
+		\includegraphics[width=0.35\textwidth]{unterschrift}\vspace*{-0.35cm}
+		\\
+		\rule[0.5ex]{12em}{0.55pt} & \rule[0.5ex]{12em}{0.55pt} \\
+		(Ort, Datum) & (Eigenhändige Unterschrift)
+		\\
+	\end{tabular*} \\
+\end{table}
 
 \newpage


### PR DESCRIPTION
Bisher wurde das Datum nicht automatisch eingetragen, sowie die Unterschrift nicht eingefügt.

Das passiert jetzt im selben Format wie in der ehrenwörtlichen Erklärung. (Ist 1:1 kopiert)