### PR TITLE
Update thesis_main.tex

### DIFF
--- a/thesis_main.tex
+++ b/thesis_main.tex
@@ -330,9 +330,13 @@ mincrossrefs = 1
 \section*{Anhang} %Überschrift "Anhang", ohne Nummerierung
 \addcontentsline{toc}{section}{\langde{Anhang}\langen{Appendix}} %Den Anhang ohne Nummer zum Inhaltsverzeichnis hinzufügen
 \begin{appendices}
+% Nachfolgende Änderungen erfolgten aufgrund von Issue 163
+\makeatletter
+\renewcommand\@seccntformat[1]{\csname the#1\endcsname:\quad}
+\makeatother
 \addtocontents{toc}{\protect\setcounter{tocdepth}{0}} %
-	\renewcommand{\thesection}{\langde{Anhang}\langen{Appendix} \arabic{section}:}
-	\renewcommand\thesubsection{\langde{Anhang}\langen{Appendix} \arabic{section}.\arabic{subsection}:}
+	\renewcommand{\thesection}{\langde{Anhang}\langen{Appendix} \arabic{section}}
+	\renewcommand\thesubsection{\langde{Anhang}\langen{Appendix} \arabic{section}.\arabic{subsection}}
 	\input{kapitel/anhang/anhang}
 \end{appendices}
 \addtocontents{toc}{\protect\setcounter{tocdepth}{2}}


### PR DESCRIPTION
Pull Request aufgrund von https://github.com/andygrunwald/FOM-LaTeX-Template/issues/163 erstellt.

Durch die Anpassung werden die Sections und Subsections weiterhin mit einem Doppelpunkt im Anhang versehen aber beim Referenzieren mir \ref{} auf den Anhang wird der Doppelpunkt nicht im Text angezeigt. Bisher war genau das der Fall.

Die Lösung ist nicht perfekt aber sie behebt das Problem und bisher konnte ich keine Nebenwirkungen entdecken.