### PR TITLE
Latex Warning ausgebaut

### DIFF
--- a/literatur/literatur.bib
+++ b/literatur/literatur.bib
@@ -56,7 +56,7 @@
 	series = {Soft skills}
 }
 
-// Werk mit mehr als drei hinterlegten Autoren, um das Verhalten von Biblatex zu demonstrieren
+% Werk mit mehr als drei hinterlegten Autoren, um das Verhalten von Biblatex zu demonstrieren
 @book{Balzert2.2008,
 	usera = {XYZWissenschaftliches Arbeiten},
 	keyword = {primary},
@@ -133,7 +133,7 @@
     title = {{Microservices}},
     year = {2017}
 }
-// sortkey: damit nach "Lucke" und nicht nach "von Lucke" sortiert wird
+% sortkey: damit nach "Lucke" und nicht nach "von Lucke" sortiert wird
 @incollection{Lucke2018,
     editor = {Heuermann, Roland and Tomenendal, Matthias and Bressem, Christian},
     author = {{von} Lucke, Jörn and Heuermann, Roland and Poder, Helmut and others},
@@ -156,7 +156,7 @@
     number = {3},
     year = {2017}
 }
-// Quelle ohne eigene Jahresangabe --> o. J. bzw. keine Datumsangabe
+% Quelle ohne eigene Jahresangabe --> o. J. bzw. keine Datumsangabe
 @online{Belastingdienst,
     usera = {{Bürgerservicenummer}},
     author = {{Belastingdienst}},

--- a/thesis_main.tex
+++ b/thesis_main.tex
@@ -27,9 +27,9 @@
    \ifde\selectlanguage{ngerman}#1\fi}
 \newcommand{\langen}[1]{%
    \ifen\selectlanguage{english}#1\fi}
+\usepackage[utf8]{luainputenc}
 \langde{\usepackage[babel,german=quotes]{csquotes}}
 \langen{\usepackage[babel,english=british]{csquotes}}
-\usepackage[utf8]{luainputenc}
 \usepackage[T1]{fontenc}
 \usepackage{fancyhdr}
 \usepackage{fancybox}

--- a/thesis_main.tex
+++ b/thesis_main.tex
@@ -68,6 +68,7 @@
 \usepackage{todonotes}
 
 % Verhindert, dass nur eine Zeile auf der nächsten Seite steht
+\setlength{\marginparwidth}{2cm}
 \usepackage[all]{nowidow}
 
 %-----------------------------------


### PR DESCRIPTION
Durch den Wechsel der Zeilen meldet Latex die folgende Fehlermeldung nicht mehr:
Package csquotes Warning: Load 'inputenc' before 'csquotes' on input line 308.

Übersetzung funktioniert weiterhin