### PR TITLE
Ibid Fussnoten

### DIFF
--- a/skripte/modsBiblatex2018.tex
+++ b/skripte/modsBiblatex2018.tex
@@ -227,7 +227,7 @@
   \iffieldundef{shorthand}
     {\ifthenelse{\ifciteibid\AND\NOT\iffirstonpage}
        {\usebibmacro{cite:ibid}}
-    {\ifthenelse{\ifnameundef{labelname}\OR\iffieldundef{labelyear}}
+    {\printtext[bibhyperref]{\ifthenelse{\ifnameundef{labelname}\OR\iffieldundef{labelyear}}
        {\usebibmacro{cite:label}%
         \setunit{\printdelim{nonameyeardelim}}}
       {\toggletrue{abx@bool@giveninits}%
@@ -235,5 +235,5 @@
         \setunit{\printdelim{nameyeardelim}}}%
       \printfield{usera}%
       \setunit{\printdelim{titleyeardelim}}%
-     \usebibmacro{cite:labeldate+extradate}}}
+     \usebibmacro{cite:labeldate+extradate}}}}
    {\usebibmacro{cite:shorthand}}}

--- a/skripte/modsBiblatex2018.tex
+++ b/skripte/modsBiblatex2018.tex
@@ -225,6 +225,8 @@
 
 \renewbibmacro*{cite}{%
   \iffieldundef{shorthand}
+    {\ifthenelse{\ifciteibid\AND\NOT\iffirstonpage}
+       {\usebibmacro{cite:ibid}}
     {\ifthenelse{\ifnameundef{labelname}\OR\iffieldundef{labelyear}}
        {\usebibmacro{cite:label}%
         \setunit{\printdelim{nonameyeardelim}}}
@@ -233,5 +235,5 @@
         \setunit{\printdelim{nameyeardelim}}}%
       \printfield{usera}%
       \setunit{\printdelim{titleyeardelim}}%
-     \usebibmacro{cite:labeldate+extradate}}
+     \usebibmacro{cite:labeldate+extradate}}}
    {\usebibmacro{cite:shorthand}}}

--- a/thesis_main.tex
+++ b/thesis_main.tex
@@ -60,8 +60,8 @@
 \renewcommand\familydefault{\sfdefault}
 \usepackage{ragged2e}
 
-% Mehrere Fussnoten nacheinander mit Komma separiert
-\usepackage[hang, multiple]{footmisc}
+% Mehrere Fussnoten nacheinander mit Komma separiert % multiple entfernt, da nicht kompatibel zu hyperref. Fix, um mehrere Fussnoten per Komma zu trennen, findet sich weiter unten
+\usepackage[hang]{footmisc}
 \setlength{\footnotemargin}{1em}
 
 % todo Aufgaben als Kommentare verfassen für verschiedene Editoren
@@ -257,6 +257,11 @@ mincrossrefs = 1
         Build=1.1
     }
 }
+
+% Mehrere Referenzen hintereinander bei Verwendung von Footcite durch Kommata trennen
+\usepackage{fnpct}
+\setfnpct{dont-mess-around}
+\AdaptNoteOpt\footcite\multfootcite
 
 %-----------------------------------
 % PlantUML

--- a/thesis_main.tex
+++ b/thesis_main.tex
@@ -139,6 +139,7 @@
 %%%% Neuer Leitfaden (2018)
 \usepackage[
 backend=biber,
+%style=ext-authoryear-ibid, % Auskommentieren und nächste Zeile kommentieren, um "Ebd." (ebenda) für sich-wiederholende Fussnoten zu nutzen
 style=ext-authoryear,
 maxcitenames=3,	% mindestens 3 Namen ausgeben bevor et. al. kommt
 maxbibnames=999,

--- a/thesis_main.tex
+++ b/thesis_main.tex
@@ -301,7 +301,7 @@ mincrossrefs = 1
 %-----------------------------------
 % Damit die hochgestellten Zahlen auch auf die Fußnote verlinkt sind (siehe Issue 169)
 %-----------------------------------
-\hypersetup{colorlinks=true, breaklinks=true, linkcolor=darkblack, menucolor=darkblack, urlcolor=darkblack, linktoc=all, bookmarksnumbered=false, pdfpagemode=UseOutlines, pdftoolbar=true}
+\hypersetup{colorlinks=true, breaklinks=true, linkcolor=darkblack, citecolor=darkblack, menucolor=darkblack, urlcolor=darkblack, linktoc=all, bookmarksnumbered=false, pdfpagemode=UseOutlines, pdftoolbar=true}
 \urlstyle{same}%gleiche Schriftart für den Link wie für den Text
 
 %-----------------------------------


### PR DESCRIPTION
thesis_main.tex und modsBiblatex2018.tex angepasst, um ibid Fussnoten (Ebd. statt sich wiederholender Quellen) zu unterstützen. Die Umstellung auf Ibid erfolgt in \usepackage[...]{biblatex} in der thesis_main.tex durch:

- Auskommentieren von: %style=ext-authoryear-ibid
- Kommentieren von: style=ext-authoryear-ibid

Weiterhin \hypersetup in der thesis_main.tex um citecolor=darkblack erweitert, um grüne Fussnoten zu verhindern (falls diese in das Quellenverzeichnis linken). Thanks to https://tex.stackexchange.com/a/847/231830

This issue resolves #151 