### PR TITLE
Änderung BibLaTeX-Vorlage : Anpassungen Mendeley Literaturverwaltung

### DIFF
--- a/skripte/modsBiblatex2018mendeley.tex
+++ b/skripte/modsBiblatex2018mendeley.tex
@@ -1,0 +1,240 @@
+\usepackage{xpatch}
+
+\setlength\bibhang{1cm}
+
+%%% Weitere Optionen
+%\boolitem[false]{citexref} %Wenn incollection, inbook, inproceedings genutzt wird nicht den zugehörigen parent auch in Literaturverzeichnis aufnehmen
+
+%Aufräumen die Felder werden laut Leitfaden nicht benötigt.
+\AtEveryBibitem{%
+\ifentrytype{book}{
+    \clearfield{issn}%
+    \clearfield{doi}%
+    \clearfield{isbn}%
+    \clearfield{url}
+    \clearfield{eprint}
+}{}
+\ifentrytype{collection}{
+  \clearfield{issn}%
+  \clearfield{doi}%
+  \clearfield{isbn}%
+  \clearfield{url}
+  \clearfield{eprint}
+}{}
+\ifentrytype{incollection}{
+  \clearfield{issn}%
+  \clearfield{doi}%
+  \clearfield{isbn}%
+  \clearfield{url}
+  \clearfield{eprint}
+}{}
+\ifentrytype{article}{
+  \clearfield{issn}%
+  \clearfield{doi}%
+  \clearfield{isbn}%
+  \clearfield{url}
+  \clearfield{eprint}
+}{}
+\ifentrytype{inproceedings}{
+  \clearfield{issn}%
+  \clearfield{doi}%
+  \clearfield{isbn}%
+  \clearfield{url}
+  \clearfield{eprint}
+}{}
+}
+
+\renewcommand*{\finentrypunct}{}%Kein Punkt am ende des Literaturverzeichnisses
+
+\renewcommand*{\newunitpunct}{\addcomma\space}
+\DeclareDelimFormat[bib,biblist]{nametitledelim}{\addcolon\space}
+\DeclareDelimFormat{titleyeardelim}{\newunitpunct}
+
+%Namen kursiv schreiben - kommentieren, wenn Namen nicht kursiv geschrieben werden sollen
+\renewcommand*{\mkbibnamefamily}{\mkbibemph}
+\renewcommand*{\mkbibnamegiven}{\mkbibemph}
+\renewcommand*{\mkbibnamesuffix}{\mkbibemph}
+\renewcommand*{\mkbibnameprefix}{\mkbibemph}
+
+% Die Trennung mehrerer Autorennamen erfolgt durch Kommata.
+% siehe Beispiele im Leitfaden S. 16
+% Die folgende Zeile würde mit Semikolon trennen
+%\DeclareDelimFormat{multinamedelim}{\addsemicolon\addspace}
+
+%Delimiter für mehrere und letzten Namen gleich setzen
+\DeclareDelimAlias{finalnamedelim}{multinamedelim}
+
+\DeclareNameAlias{default}{family-given}
+\DeclareNameAlias{sortname}{default}  %Nach Namen sortieren
+
+
+\DeclareFieldFormat{editortype}{\mkbibparens{#1}}
+\DeclareDelimFormat{editortypedelim}{\addspace}
+\DeclareFieldFormat{translatortype}{\mkbibparens{#1}}
+\DeclareDelimFormat{translatortypedelim}{\addspace}
+\DeclareDelimFormat[bib,biblist]{innametitledelim}{\addcomma\space}
+
+\DeclareFieldFormat*{citetitle}{#1}
+\DeclareFieldFormat*{title}{#1}
+\DeclareFieldFormat*{booktitle}{#1}
+\DeclareFieldFormat*{journaltitle}{#1}
+
+\xpatchbibdriver{misc}
+  {\usebibmacro{organization+location+date}\newunit\newblock}
+  {}
+  {}{}
+
+\DeclareFieldFormat[misc]{date}{\mkbibparens{#1}}
+\DeclareFieldFormat{urltime}{\addspace #1\addspace \langde{Uhr}\langen{MEZ}}
+\DeclareFieldFormat{urldate}{%urltime zu urldate hinzufügen
+  [\langde{Zugriff}\langen{Access}\addcolon\addspace
+  #1\printfield{urltime}]
+}
+\DeclareFieldFormat[misc]{url}{<\url{#1}>}
+\renewbibmacro*{url+urldate}{%
+  \usebibmacro{url}%
+  \ifentrytype{misc}
+    {\setunit*{\addspace}%
+     \iffieldundef{year}
+       {\printtext[date]{\langde{keine Datumsangabe}\langen{no Date} }}
+       {\usebibmacro{date}}}%
+    {}%
+  \setunit*{\addspace}%
+  \usebibmacro{urldate}
+  }
+
+%Verhindern, dass bei mehreren Quellen des gleichen Autors im gleichen Jahr
+%Buchstaben nach der Jahreszahl angezeigt werden wenn sich das Keyword in shorttitle unterscheidet.
+\DeclareExtradate{
+  \scope{
+    \field{labelyear}
+    \field{year}
+    }
+    \scope{
+      \field{shorttitle}
+     }
+}
+
+%% Anzeige des Jahres nach dem Stichwort (shorttitle) im Literaturverzeichnis
+%% Wenn das Jahr bei Online (Mendeley = misc)-Quellen nicht explizit angegeben wurde, wird nach
+%% dem Stichwort 'o. J.' ausgegeben. Nach der URL steht dann 'keine
+%% Datumsangabe'. Ist das Jahr definiert, wird es an beiden Stellen ausgegeben.
+%% Das Zugriffsdatum (urldate) spielt hier keine Rolle.
+%% Für Nicht-Online (Mendeley = misc)-Quellen wird nichts geändert.
+\renewbibmacro*{date+extradate}{%
+  \printtext[parens]{%
+    \printfield{shorttitle}%
+    \setunit{\printdelim{titleyeardelim}}%
+    \ifentrytype{misc}
+       {\setunit*{\addspace\addcomma\addspace}%
+         \iffieldundef{year}
+           {\bibstring{nodate}}
+       {\printlabeldateextra}}%
+       {\printlabeldateextra}}}
+
+%% Anzeige des Jahres nach dem Stichwort (shorttitle) in der Fussnote
+%% das Stichwort hat der Aufrufer hier schon ausgegeben.
+%% siehe auch Kommentar zu: \renewbibmacro*{date+extradate}
+\renewbibmacro*{cite:labeldate+extradate}{%
+    \ifentrytype{misc}
+       {\setunit*{\addspace\addcomma\addspace}%
+         \iffieldundef{year}
+           {\bibstring{nodate}}
+       {\printlabeldateextra}}%
+       {\printlabeldateextra}}
+
+
+\DefineBibliographyStrings{german}{
+  nodate    = {{}o.\adddot\addspace J\adddot},
+  andothers = {et\addabbrvspace al\adddot}
+}
+\DefineBibliographyStrings{english}{
+  nodate    = {{}n.\adddot\addspace d\adddot},
+  andothers = {et\addabbrvspace al\adddot}
+}
+\DeclareSourcemap{
+  \maps[datatype=bibtex]{
+    \map{
+      \step[notfield=translator, final]
+      \step[notfield=editor, final]
+      \step[fieldset=author, fieldvalue={{{\langde{o\noexpand\adddot\addspace V\noexpand\adddot}\langen{Anon}}}}]
+    }
+    \map{
+      \pernottype{misc}
+      \step[fieldset=location, fieldvalue={\langde{o\noexpand\adddot\addspace O\noexpand\adddot}\langen{s\noexpand\adddot I\noexpand\adddot}}]
+    }
+  }
+}
+
+\renewbibmacro*{cite}{%
+  \iffieldundef{shorthand}
+    {\ifthenelse{\ifnameundef{labelname}\OR\iffieldundef{labelyear}}
+       {\usebibmacro{cite:label}%
+        \setunit{\printdelim{nonametitledelim}}}
+       {\printnames{labelname}%
+        \setunit{\printdelim{nametitledelim}}}%
+     \printfield{shorttitle}%
+     \setunit{\printdelim{titleyeardelim}}%
+     \usebibmacro{cite:labeldate+extradate}}
+    {\usebibmacro{cite:shorthand}}}
+
+    \renewcommand*{\jourvoldelim}{\addcomma\addspace}% Trennung zwischen journalname und Volume. Sonst Space; Laut Leitfaden richtig
+    %Aufgrund der Änderung bzgl des Issues 169 in der thesis_main.tex musste ich die Zeile auskommentieren. Konnte aber das Verhalten, dass die Fußnoten grün sind, im nachhinein nicht feststellen.
+    %\hypersetup{hidelinks} %sonst sind Fußnoten grün. Dadurch werden Links allerdings nicht mehr farbig dargestellt
+
+\renewbibmacro*{journal+issuetitle}{%
+  \usebibmacro{journal}%
+  \setunit*{\jourvoldelim}%
+  \iffieldundef{series}
+    {}
+    {\setunit*{\jourserdelim}%
+     \printfield{series}%
+     \setunit{\servoldelim}}%
+  \iffieldundef{volume}
+    {}
+    {\printfield{volume}}
+  \iffieldundef{labelyear}
+  {}
+  {
+  (\thefield{year}) %Ansonsten wird wenn kein Volume angegeben ist ein Komma vorangestellt
+  }
+  \setunit*{\addcomma\addspace Nr\adddot\addspace}
+  \printfield{number}
+  \iffieldundef{eid}
+  {}
+  {\printfield{eid}}
+}
+
+% Postnote ist der Text in der zweiten eckigen Klammer bei einem Zitat
+% wenn es keinen solchen Eintrag gibt, dann auch nicht ausgeben, z.B. 'o. S.'
+% Wenn man das will, kann man das 'o. S.' ja explizit angeben. Andernfalls steht
+% sonst auch bei Webseiten 'o. S.' da, was laut Leitfaden nicht ok ist.
+\renewbibmacro*{postnote}{%
+  \setunit{\postnotedelim}%
+  \iffieldundef{postnote}
+    {} %{\printtext{\langde{o.S\adddot}\langen{no page number}}}
+    {\printfield{postnote}}}
+
+% Abstand bei Änderung Anfangsbuchstabe ca. 1.5 Zeilen
+\setlength{\bibinitsep}{0.75cm}
+
+% nur in den Zitaten/Fussnoten den Vornamen abkürzen (nicht im
+% Literaturverzeichnis)
+
+\DeclareDelimFormat{nonameyeardelim}{\addcomma\space}
+\DeclareDelimFormat{nameyeardelim}{\addcomma\space}
+
+\renewbibmacro*{cite}{%
+  \iffieldundef{shorthand}
+    {\ifthenelse{\ifciteibid\AND\NOT\iffirstonpage}
+       {\usebibmacro{cite:ibid}}
+    {\printtext[bibhyperref]{\ifthenelse{\ifnameundef{labelname}\OR\iffieldundef{labelyear}}
+       {\usebibmacro{cite:label}%
+        \setunit{\printdelim{nonameyeardelim}}}
+      {\toggletrue{abx@bool@giveninits}%
+        \printnames[family-given]{labelname}%
+        \setunit{\printdelim{nameyeardelim}}}%
+      \printfield{shorttitle}%
+      \setunit{\printdelim{titleyeardelim}}%
+     \usebibmacro{cite:labeldate+extradate}}}}
+   {\usebibmacro{cite:shorthand}}}


### PR DESCRIPTION
1. Problembeschreibung:

Laut Leitfadens muss nach dem(n) Verfasser(n) und vor der Jahreszahl ein Stichwort (ein bis zwei Wörter maximal) stehen (abh. vom Inhaltstyp, z. B. Monographie, Zeitschriftenartikel, etc.).

2. Hintergrund (Mendeley-Literarturverwaltung):

In der Mendeley-Literaturverwaltungssoftwarekeinen ist es derzeit nicht möglich neue Inhaltstypen zu erstellen bzw. hinzuzufügen.
Der in der Biblatex-Vorlage von 2018 (Dateiname: modsBiblatex2018.tex) verwendete Feldtyp 'usera' wird deshalb von der Mendeley-Literaturverwaltung nicht erkannt. 

3. Vorschlag für Problembehebung:

Als Workaround müssen bereits bestehenden Feldtypen (z. B. 'shorttitle' und 'misc'), die von einem bestimmten Inhaltstypen (book, article, etc.) nicht verwendet werden, da evtl. nicht im Studienleitfaden gefordert, zweckentfremdet verwendet werden.

Vorschläge für Feldttyp-Änderungen in der BibLaTeX-Datei:

a) Feldtyp 'usera' (FOM-LaTeX-Vorlage) soll durch Feldtyp 'shorttitle' (Mendeley) ersetzt werden
b) Feldtyp 'online' (FOM-LaTeX-Vorlage)soll durch Feldtyp 'misc' (Mendeley)ersetzt werden

Die neu hinzugefügte Datei 'modsBiblatex2018mendeley.tex' enthält bereits diese Änderung und muss nur in der Haupt-Datei 'thesis_main.tex' wie folgt eingebunden werden:   

\input{skripte/modsBiblatex2018mendeley}

4. Behobene Fehler durch die o. g. Änderungen

a) Wird innerhalb der Mendeley-GUI das Dokumenten-Attribut 'Short Title:' mit einem beliebigen Stichwort befüllt, so erscheint es sowohl in der Fußnote als auch im Literaturverzeichnis 
b) Wird in Mendeley der für Webseiten vorgesehene Inhaltstyp 'Web page' verwendet, so werden auch die URLs im Literaturverzeichnis angezeigt. Ohne die Umbenennung des Feldtyps 'online' zu 'misc' werden die in *.bib-Dateien verwendeten 'online'-Einträge NICHT im Literaturverzeichnis angezeigt, da Mendeley für Webseiten nur den Feldtype 'misc' vorsieht.