### PR TITLE
Update Dockerfile, avoid $TERM warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,11 @@
 # 	or use 
 #	docker-compose up
 
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN echo 'deb [trusted=yes] http://ppa.launchpad.net/jonathonf/texlive-2018/ubuntu bionic main' > /etc/apt/sources.list.d/texlive.list \
-	&& echo 'deb-src [trusted=yes] http://ppa.launchpad.net/jonathonf/texlive-2018/ubuntu bionic main' >> /etc/apt/sources.list.d/texlive.list \
-	&& apt-get update \
+RUN apt-get update \
 	&& apt-get install -y \
 		wget \
 		texlive-latex-recommended \
@@ -19,7 +17,7 @@ RUN echo 'deb [trusted=yes] http://ppa.launchpad.net/jonathonf/texlive-2018/ubun
 		texlive-fonts-recommended \
 		texlive-bibtex-extra \
 		texlive-lang-german \
-		texlive-generic-extra \
+		texlive-plain-generic \
 		texlive-luatex \
 		biber \
 		xz-utils \

--- a/compile.sh
+++ b/compile.sh
@@ -4,6 +4,8 @@ CURRENT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 compile=""
 biberarg=""
 CMD_LATEX=lualatex
+# avoid $TEMP warning
+export TERM=xterm-256color
 
 echo "Compiling in Language: $1"
 if [ "$1" = "en" ] || [ "$2" = "en" ] ; then

--- a/compile.sh
+++ b/compile.sh
@@ -4,7 +4,7 @@ CURRENT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 compile=""
 biberarg=""
 CMD_LATEX=lualatex
-# avoid $TEMP warning
+# avoid $TERM warning
 export TERM=xterm-256color
 
 echo "Compiling in Language: $1"


### PR DESCRIPTION
- use Ubuntu 20.04 as base image
- only use tex-live packages from the Ubuntu repos
- replace `texlive-generic-extra` with `texlive-plain-generic` because the former is not available anymore in Ubuntu 20.04
- export the `$TERM` environment variable in the `compile.sh` script, as it lead to a warning because it was not set

Was there a particular reason to add that `texlive-2018` to the sources? Could removing it lead to breaking something?