### PR TITLE
Fix broken links to acronyms and list of symbols

### DIFF
--- a/thesis_main.tex
+++ b/thesis_main.tex
@@ -359,8 +359,8 @@ mincrossrefs = 1
 %-----------------------------------
 % Falls das Abkürzungsverzeichnis nicht im Inhaltsverzeichnis angezeigt werden soll
 % dann folgende Zeile auskommentieren.
-\addcontentsline{toc}{section}{\abbreHeadingName}
 \input{abkuerzungen/acronyms}
+\addcontentsline{toc}{section}{\abbreHeadingName}
 \newpage
 
 %-----------------------------------
@@ -369,9 +369,9 @@ mincrossrefs = 1
 % In Overleaf führt der Einsatz des Symbolverzeichnisses zu einem Fehler, der aber ignoriert werdne kann
 % Falls das Symbolverzeichnis nicht im Inhaltsverzeichnis angezeigt werden soll
 % dann folgende Zeile auskommentieren.
-\addcontentsline{toc}{section}{\symheadingname}
 \input{skripte/symbolDef}
 \listofsymbols
+\addcontentsline{toc}{section}{\symheadingname}
 \newpage
 
 %-----------------------------------


### PR DESCRIPTION
#### What type of Pull Request is this?

Bug.

#### What this Pull Request does / why we need it:

This fixes broken links in the PDF file to the acronyms and the list of symbols. 
With this fix, if you click in the PDF file on acronyms and on the list of symbols, you get to the correct page. 
W/o this fix, you land on the wrong pages (the page before).

#### Which issue(s) this PR fixes:

None.-

#### Special notes for your reviewer:

Tested.
