### PR TITLE
:bug: Fix hyperref not linking to table of abbreviations correctly

### DIFF
--- a/thesis_main.tex
+++ b/thesis_main.tex
@@ -369,7 +369,7 @@ mincrossrefs = 1
 % In Overleaf führt der Einsatz des Symbolverzeichnisses zu einem Fehler, der aber ignoriert werdne kann
 % Falls das Symbolverzeichnis nicht im Inhaltsverzeichnis angezeigt werden soll
 % dann folgende Zeile auskommentieren.
-\addcontentsline{toc}{section}{\symheadingname}
+\phantomsection\addcontentsline{toc}{section}{\symheadingname}
 \input{skripte/symbolDef}
 \listofsymbols
 \newpage


### PR DESCRIPTION
#### What type of Pull Request is this?

Bug


#### What this Pull Request does / why we need it:

When working with `\addcontentsline`, hyperref needs a `\phantomsection` to align the hyperref correctly.

#### Special notes for your reviewer:

Dieser Fehler ist mir kurz vor Abgabe meiner Arbeit selber aufgefallen.