### PR TITLE
make wordcount executable and set syntax to bash

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -58,6 +58,10 @@ rm *.out 2> /dev/null
 rm *.toc 2> /dev/null
 rm *.run.xml 2> /dev/null
 rm *.lot 2> /dev/null
+rm *.sub 2> /dev/null
+rm *.suc 2> /dev/null
+rm *.syc 2> /dev/null
+rm *.sym 2> /dev/null
 
 echo "PDF Compile: Success"
 

--- a/countwords.sh
+++ b/countwords.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 echo "Um dieses Skript zu nutzen muss detex auf dem Rechner installiert sein"
 echo "Unter macOS kann es mit dem folgenden Befehl installiert werden: brew install opendetex"
 
@@ -12,9 +14,9 @@ while read p; do
   # end txt when end was found
   echo "$p" | grep $ENDING && break
   if [ "$FOUNDBEGIN" == "y" ]
-      then
-          echo "$p" >>wordcounts.txt
-          # echo "$p" | sed 's/\[[\w. ]*\][[\w. ]*\]\w+\.\w+/ /g' >>wordcounts.txt
+  then
+        echo "$p" >> wordcounts.txt
+        # echo "$p" | sed 's/\[[\w. ]*\][[\w. ]*\]\w+\.\w+/ /g' >>wordcounts.txt
   fi
   # start txt when beginning was found
   echo "$p" | grep $BEGINNING >/dev/null && FOUNDBEGIN="y"


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please follow the template and take some minutes to fill out all sections.
It will speed up the review process a lot.
-->

#### What type of Pull Request is this?

bug

<!--
Add one of the following types:

bug
cleanup
documentation
feature

-->

#### What this Pull Request does / why we need it:

This fix bash specific error in word count script and make wordcount.sh executable.

Error message:

```
./countwords.sh: 14: [: y: unexpected operator
./countwords.sh: 14: [: y: unexpected operator
./countwords.sh: 14: [: y: unexpected operator
./countwords.sh: 14: [: y: unexpected operator
```

Details under: https://stackoverflow.com/questions/20449543/shell-equality-operators-eq

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when the Pull Request is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:

<!--
Anything and everything to add more context.
Things like:
* Where does the change come from? The motivation?
* What were your thoughts during development? The why you decided the way you did.

Any information will help the reviewer.
-->