### PR TITLE
Update zur aktuellen Version des Leitfaden jan 2024

### DIFF
--- a/kapitel/kapitel_2/kapitel_2.tex
+++ b/kapitel/kapitel_2/kapitel_2.tex
@@ -110,21 +110,17 @@ Von den vielen verfügbaren Literatur-Paketen habe ich mich für Biblatex entsch
 
 In der für den Leitfaden 2018 aktualisierten Version sind außerdem Beispiele für \enquote{online},\footcite[Vgl.][]{website:angular:aboutAngular} also Webseiten, und \enquote{article},\footcite[Vgl.][S. 140]{Decker2009} also wissenschaftliche Artikel, enthalten.
 
-Laut Leitfaden sollen maximal 3 Autoren genannt werden und danach mit
-\enquote{et. al.} bzw. \enquote{u.a.} ergänzt werden. Damit im Literaturverzeichnis auch nur max.
-3 Autoren stehen, muss man beim Füllen der literatur.bib-Datei darauf achten auch nur 3
-einzutragen. Weitere Autoren kann man einfach mit \enquote{and others} ergänzen.
-Siehe Eintrag für \enquote{Balzert.2008}. Zitiert man dann diese Werk, werden auch in
-der Fussnote alle Autoren korrekt genannt wie in dieser
-Fußnote\footcite[Vgl.][S. 1]{Balzert.2008} zu sehen ist.
-
-Hat man dagegen mehr als 3 Autoren in der bib-Datei hinterlegt, stehen im
-Literaturverzeichnis alle drin. In der Fussnote dagegen, steht nur
-einer\footcite[Vgl.][S. 1]{Balzert2.2008}, was dem Leitfaden widerspricht.
-
-Die Anzahl von 3 wird übrigens über die Option \enquote{maxcitenames=3} des
-biblatex-Packages gesetzt. Man muss selbst schauen, dass die Anzahl der Autoren
-in den Bib-Dateien mit der Optionseinstellung übereinstimmt.
+Laut Leitfaden sollen in einer Fußnote maximal 2 Autoren genannt werden. Bei Quellen mit drei oder 
+mehr Verfassern wird nur der erste Autor aufgeführt, gefolgt von
+\enquote{et. al.} bzw. \enquote{u.a.}. Im Literaturverzeichnis hingegen müssen alle Autoren angegeben werden.
+Beim Zitieren dieser Werke werden in der Fußnote die Autoren korrekt genannt, wie in 
+dieser Fußnote\footcite[Vgl.][S. 1]{Balzert0.2008},
+dieser Fußnote\footcite[Vgl.][S. 1]{Balzert1.2008} und
+dieser Fußnote\footcite[Vgl.][S. 1]{Balzert2.2008} zu sehen ist.
+In der Datei \texttt{literatur/literatur.bib} können daher alle Autoren ohne Bedenken erfasst werden.
+BibTeX findet die richtige Zitierweise automatisch.
+Die maximale Anzahl der angezeigten Autoren in Zitaten wird übrigens durch die Option \enquote{maxcitenames=3} des
+\textit{biblatex}-Packages festgelegt.
 
 \subsubsection{Beispielfußnoten}
 Diese Fussnote soll zeigen, wie mit einem \enquote{von} vor dem Namen des Autors

--- a/literatur/literatur.bib
+++ b/literatur/literatur.bib
@@ -44,10 +44,25 @@
 	publisher = {Pearson Studium},
 	isbn = {978-3827370464}
 }
-@book{Balzert.2008,
+
+% Werk mit einem hinterlegtem Autor, um das Verhalten von Biblatex zu demonstrieren
+@book{Balzert0.2008,
 	usera = {Wissenschaftliches Arbeiten},
 	keyword = {primary},
-	author = {Balzert, Helmut and Bendisch, Roman and Kern, Uwe and others},
+	author = {Balzert, Helmut},
+	year = {2008},
+	title = {Wissenschaftliches Arbeiten: Wissenschaft, Quellen, Artefakte, Organisation, Pr{\"a}sentation},
+	location = {Herdecke [u.a.]},
+	publisher = {W3L-Verl.},
+	isbn = {978-3937137599},
+	series = {Soft skills}
+}
+
+% Werk mit zwei hinterlegten Autoren, um das Verhalten von Biblatex zu demonstrieren
+@book{Balzert1.2008,
+	usera = {Wissenschaftliches Arbeiten},
+	keyword = {primary},
+	author = {Balzert, Helmut and Bendisch, Roman},
 	year = {2008},
 	title = {Wissenschaftliches Arbeiten: Wissenschaft, Quellen, Artefakte, Organisation, Pr{\"a}sentation},
 	location = {Herdecke [u.a.]},
@@ -58,9 +73,9 @@
 
 % Werk mit mehr als drei hinterlegten Autoren, um das Verhalten von Biblatex zu demonstrieren
 @book{Balzert2.2008,
-	usera = {XYZWissenschaftliches Arbeiten},
+	usera = {Wissenschaftliches Arbeiten},
 	keyword = {primary},
-	author = {Balzert2, Helmut and Bendisch, Roman and Kern, Uwe and Sch{\"a}fer, Christian and Schr{\"o}der, Marion and Zeppenfeld, Klaus},
+	author = {Balzert, Helmut and Bendisch, Roman and Kern, Uwe and Sch{\"a}fer, Christian and Schr{\"o}der, Marion and Zeppenfeld, Klaus},
 	year = {2008},
 	title = {Wissenschaftliches Arbeiten: Wissenschaft, Quellen, Artefakte, Organisation, Pr{\"a}sentation},
 	location = {Herdecke [u.a.]},


### PR DESCRIPTION
Im Leitfaden von Januar 2024 steht:

```
Um den Fußnotenapparat übersichtlich zu gestalten, kann in den Fällen, in denen sich
drei Verfasser oder mehr für einen Beitrag verantwortlich zeichnen, auf die komplette
Nennung der Verfasser in den Fußnoten (nicht im Literaturverzeichnis!!!) verzichtet wer-
den. Stattdessen beschränkt sich die Angabe auf den Namen des zuerst genannten Ver-
fassers mit dem Zusatz „et al.“ (= et alii) oder auch „u. a.“ (= und andere).

```
Dies entspricht nicht mehr der Beschreibung in der Datei 
https://github.com/andygrunwald/FOM-LaTeX-Template/blob/d8a32adf75f4dd65be7cd2b24fddf7b505608114/kapitel/kapitel_2/kapitel_2.tex#L113-L119

Diese PR vebessert den Inhalt des 4 Jahre alten Kapitels.

Die Anmerkung `(nicht im Literaturverzeichnis!!!)` könnte durch die in den letzten Jahren mit diesem Template geschriebenen Arbeiten entstanden sein. Ich war auch etwas verwirrt. :D

:shipit: 
